### PR TITLE
fix: Extra newline in highlighted code blocks

### DIFF
--- a/styles/prism.js
+++ b/styles/prism.js
@@ -2,6 +2,9 @@ import { css } from '@emotion/core';
 import { theme } from '@chakra-ui/core';
 
 const prismBaseTheme = css`
+  code {
+    white-space: pre;
+  }
   code[class*='language-'],
   pre[class*='language-'] {
     color: ${theme.colors.gray[800]};
@@ -9,7 +12,6 @@ const prismBaseTheme = css`
     font-family: ${theme.fonts.mono};
     font-size: ${theme.fontSizes[2]};
     text-align: left;
-    white-space: pre;
     word-spacing: normal;
     word-break: normal;
     word-wrap: normal;
@@ -33,6 +35,7 @@ const prismBaseTheme = css`
     overflow: auto;
     min-width: 100%;
     font-size: 0.9rem;
+    white-space: nowrap;
   }
   :not(pre) > code[class*='language-'],
   pre[class*='language-'] {


### PR DESCRIPTION
This PR fixes an issue where highlighted code blocks show an extra empty line on Firefox, see j0lv3r4/mdx-prism#4.

Before:
<img width="738" alt="CleanShot 2020-06-09 at 09 09 24@2x" src="https://user-images.githubusercontent.com/1174092/84117157-5ab2ad00-aa31-11ea-9dbb-987c61d2799f.png">

After:
<img width="749" alt="CleanShot 2020-06-09 at 09 09 07@2x" src="https://user-images.githubusercontent.com/1174092/84117180-630ae800-aa31-11ea-95b7-e68941040b3a.png">
