### PR TITLE
Fix google auth syntax in Next.js + YT article

### DIFF
--- a/pages/blog/youtube-api-nextjs.mdx
+++ b/pages/blog/youtube-api-nextjs.mdx
@@ -139,7 +139,7 @@ export default async (_, res) => {
   });
 
   const youtube = google.youtube({
-    auth,
+    auth: googleAuth,
     version: 'v3'
   });
 
@@ -165,7 +165,7 @@ export default async (_, res) => {
   });
 
   const youtube = google.youtube({
-    auth,
+    auth: googleAuth,
     version: 'v3'
   });
 


### PR DESCRIPTION
Hi Rob!

I found your article about YouTube API integration extremely valuable, however one part didn't work for me.

Copy-pasting
```
  const youtube = google.youtube({
    auth,
    version: 'v3'
  })
```

has left me with `ReferenceError: auth is not defined`

I changed my code to

```
  const youtube = google.youtube({
    auth: googleAuth,
    version: 'v3'
  })
```

and it worked.

Just leaving it here. Totally possible that there are some assumptions in the article that I have missed. Anyway, since it scores quite high on Google, I recon that it should be more copy-paste friendly.

Irrelevant if the mistake is on my side.

Once again, thanks for the tutorial! Hope you're having a great day 😄