### PR TITLE
Sticky navbar covering headings

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,4 @@
+const { spacing } = require('tailwindcss/defaultTheme');
 const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
@@ -19,6 +20,9 @@ module.exports = {
               },
               code: { color: theme('colors.blue.400') }
             },
+            'h2,h3,h4': {
+              'scroll-margin-top': spacing[32]
+            },
             code: { color: theme('colors.pink.500') },
             'blockquote p:first-of-type::before': false,
             'blockquote p:last-of-type::after': false
@@ -38,9 +42,10 @@ module.exports = {
               borderLeftColor: theme('colors.gray.700'),
               color: theme('colors.gray.300')
             },
-            h2: { color: theme('colors.gray.100') },
-            h3: { color: theme('colors.gray.100') },
-            h4: { color: theme('colors.gray.100') },
+            'h2,h3,h4': {
+              color: theme('colors.gray.100'),
+              'scroll-margin-top': spacing[32]
+            },
             hr: { borderColor: theme('colors.gray.700') },
             ol: {
               li: {


### PR DESCRIPTION
Fixes #242 

I am using `scroll-top-margin` offset.
Here is its compatibility: [caniuse](https://caniuse.com/?search=scroll-margin-top)

Working fine in chrome and firefox (mobile and desktop). 
Not sure about Safari :smile: 

![fix](https://user-images.githubusercontent.com/40598945/101600440-4de33600-3a21-11eb-858d-7f4139d60d1c.gif)
