### PR TITLE
Fix important typo in ConsCard.js

### DIFF
--- a/components/ConsCard.js
+++ b/components/ConsCard.js
@@ -1,7 +1,7 @@
 export default function ConsCard({ title, cons }) {
   return (
     <div className="border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-900 rounded p-6 my-6 w-full">
-      <span>{`You might use ${title} if...`}</span>
+      <span>{`You might not want to use ${title} if...`}</span>
       <div className="mt-4">
         {cons.map((con) => (
           <div key={con} className="flex font-medium items-baseline mb-2">


### PR DESCRIPTION
It had the same title description as ProsCard.js, so I included a 'not' in the text.