### PR TITLE
Use fs promises with async/await

### DIFF
--- a/lib/mdx.js
+++ b/lib/mdx.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import { promises as fs } from 'fs';
 import matter from 'gray-matter';
 import mdxPrism from 'mdx-prism';
 import path from 'path';
@@ -10,13 +10,13 @@ import MDXComponents from '@/components/MDXComponents';
 const root = process.cwd();
 
 export async function getFiles(type) {
-  return fs.readdirSync(path.join(root, 'data', type));
+  return await fs.readdir(path.join(root, 'data', type));
 }
 
 export async function getFileBySlug(type, slug) {
   const source = slug
-    ? fs.readFileSync(path.join(root, 'data', type, `${slug}.mdx`), 'utf8')
-    : fs.readFileSync(path.join(root, 'data', `${type}.mdx`), 'utf8');
+    ? await fs.readFile(path.join(root, 'data', type, `${slug}.mdx`), 'utf8')
+    : await fs.readFile(path.join(root, 'data', `${type}.mdx`), 'utf8');
 
   const { data, content } = matter(source);
   const mdxSource = await renderToString(content, {
@@ -43,10 +43,11 @@ export async function getFileBySlug(type, slug) {
 }
 
 export async function getAllFilesFrontMatter(type) {
-  const files = fs.readdirSync(path.join(root, 'data', type));
+  const files = await fs.readdir(path.join(root, 'data', type));
 
-  return files.reduce((allPosts, postSlug) => {
-    const source = fs.readFileSync(
+  return files.reduce(async (allPostsPromise, postSlug) => {
+    const allPosts = await allPostsPromise;
+    const source = await fs.readFile(
       path.join(root, 'data', type, postSlug),
       'utf8'
     );
@@ -59,5 +60,5 @@ export async function getAllFilesFrontMatter(type) {
       },
       ...allPosts
     ];
-  }, []);
+  }, Promise.resolve([]));
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "dev": "next",
     "start": "next start"
   },
+  "engines": {
+    "node": ">=12"
+  },
   "dependencies": {
     "@mapbox/rehype-prism": "0.5.0",
     "@mdx-js/loader": "1.6.22",


### PR DESCRIPTION
Hey, thanks for open sourcing your personal site. It's helped me learn Next.js as I rebuild my own site.

I came across the ability to import the `fs` standard lib module as `import { promises as fs } from 'fs'` while looking into how to add Typescript to Next.js and thought you might want to use it.

Cheers