### PR TITLE
Fix Autolink Headings

### DIFF
--- a/lib/mdx.js
+++ b/lib/mdx.js
@@ -23,8 +23,8 @@ export async function getFileBySlug(type, slug) {
     components: MDXComponents,
     mdxOptions: {
       remarkPlugins: [
-        require('remark-autolink-headings'),
         require('remark-slug'),
+        require('remark-autolink-headings'),
         require('remark-code-titles')
       ],
       rehypePlugins: [mdxPrism]


### PR DESCRIPTION
I was exploring using MDX as you have (amazing blog btw!) and thought I would share!

Based on a comment here: https://github.com/hashicorp/next-mdx-remote/issues/74#issuecomment-747104595 it seems that the ordering of your plugins is important (that's why none of your headings are linked at the moment!

Hope this helps!