### PR TITLE
Add missing leading slash to "Discuss on Twitter" links

### DIFF
--- a/layouts/blog.js
+++ b/layouts/blog.js
@@ -7,7 +7,7 @@ import ViewCounter from '@/components/ViewCounter';
 import BlogSeo from '@/components/BlogSeo';
 
 const editUrl = (slug) =>
-  `https://github.com/leerob/leerob.io/edit/master/data/blog${slug}.mdx`;
+  `https://github.com/leerob/leerob.io/edit/master/data/blog/${slug}.mdx`;
 const discussUrl = (slug) =>
   `https://mobile.twitter.com/search?q=${encodeURIComponent(
     `https://leerob.io/blog/${slug}`

--- a/layouts/blog.js
+++ b/layouts/blog.js
@@ -10,7 +10,7 @@ const editUrl = (slug) =>
   `https://github.com/leerob/leerob.io/edit/master/data/blog${slug}.mdx`;
 const discussUrl = (slug) =>
   `https://mobile.twitter.com/search?q=${encodeURIComponent(
-    `https://leerob.io/blog${slug}`
+    `https://leerob.io/blog/${slug}`
   )}`;
 
 export default function BlogLayout({ children, frontMatter }) {


### PR DESCRIPTION
Hello!

Fantastic blog. Been looking at it for some inspiration for my own Next/MDX site :-) 


I noticed your "Share on Twitter" links are broken, resulting in the following: 

![image](https://user-images.githubusercontent.com/1609336/103186018-e6384200-488c-11eb-962b-65d6efc89c7c.png)

You'll notice the missing slash after blog. This PR adds that, ie `https://leerob.io/blogresume` -> `https://leerob.io/blog/resume`.

Hope it helps! 