### PR TITLE
Increasing the page size for the GitHub repos request

### DIFF
--- a/pages/api/github.js
+++ b/pages/api/github.js
@@ -1,7 +1,7 @@
 export default async (_, res) => {
   const userResponse = await fetch('https://api.github.com/users/leerob');
   const userReposResponse = await fetch(
-    'https://api.github.com/users/leerob/repos'
+    'https://api.github.com/users/leerob/repos?per_page=100'
   );
 
   const user = await userResponse.json();


### PR DESCRIPTION
By default, GitHub returns up to 30 repos in their response, and since you have more than that you are not counting a few stars.
Increasing the page size returns 47 repos and increases the stars from 1,787 to 2,970.

If you want to make this more future-proof you can request subsequent pages while there are more items, with something like this:

```js
export default async (_, res) => {
  const userResponse = await fetch('https://api.github.com/users/leerob');
  let repositories = [];
  let page = 0;
  let partialUserRepos = [];
  do {
    const userReposResponse = await fetch(
      'https://api.github.com/users/leerob/repos?per_page=100&page=' + page
    );
    partialUserRepos = await userReposResponse.json();
    repositories = repositories.concat(partialUserRepos);
    page++;
  } while (partialUserRepos.length === 100);

  const user = await userResponse.json();

  const mine = repositories.filter((repo) => !repo.fork);
  const stars = mine.reduce((accumulator, repository) => {
    return accumulator + repository['stargazers_count'];
  }, 0);

  res.setHeader(
    'Cache-Control',
    'public, s-maxage=1200, stale-while-revalidate=600'
  );

  return res.status(200).json({
    followers: user.followers,
    stars
  });
};
```