### PR TITLE
Fixes customLink error when clicking a header-link

### DIFF
--- a/components/MDXComponents.js
+++ b/components/MDXComponents.js
@@ -12,8 +12,13 @@ import Step from '@/components/Step';
 
 const CustomLink = (props) => {
   const href = props.href;
-  const isInternalLink = href && (href.startsWith('/') || href.startsWith('#'));
+  const isInternalLink = href && href.startsWith("/")
+  const isHeaderLink = href && href.startsWith("#")
 
+  if (isHeaderLink) {
+    return <a {...props} />
+  }
+  
   if (isInternalLink) {
     return (
       <Link href={href}>


### PR DESCRIPTION
Fixes the error `href interpolation failed` error when clicking a link to a header in a blog post
Error: `The provided `href` (/blog/[slug]#a-header) value is missing query values (slug) to be interpolated properly.`

Steps to reproduce the error:
- create a blog post with a header '# A header' 
- link it with `[A header](#a-header)`
- click the header link

Error Link: https://github.com/vercel/next.js/blob/master/errors/href-interpolation-failed.md
Based on the Error Link above, the error is from next/link component treating a header-link (starts with a '#') as a dynamic route 'blog/blog-title/[#a-header]'

Added a isHeaderLink condition, if true will simply return <a {...props} />