### PR TITLE
Do not use destructuring for environment variables

### DIFF
--- a/data/blog/spotify-api-nextjs.mdx
+++ b/data/blog/spotify-api-nextjs.mdx
@@ -77,11 +77,9 @@ We can now request an access token using our client ID, client secret, and `refr
 ```js:lib/spotify.js
 import querystring from 'querystring';
 
-const {
-  SPOTIFY_CLIENT_ID: client_id,
-  SPOTIFY_CLIENT_SECRET: client_secret,
-  SPOTIFY_REFRESH_TOKEN: refresh_token
-} = process.env;
+const client_id = process.env.SPOTIFY_CLIENT_ID;
+const client_secret = process.env.SPOTIFY_CLIENT_SECRET;
+const refresh_token = process.env.SPOTIFY_REFRESH_TOKEN;
 
 const basic = Buffer.from(`${client_id}:${client_secret}`).toString('base64');
 const TOKEN_ENDPOINT = `https://accounts.spotify.com/api/token`;

--- a/data/snippets/spotify-top-tracks.mdx
+++ b/data/snippets/spotify-top-tracks.mdx
@@ -27,11 +27,9 @@ export default async (_, res) => {
 import fetch from 'isomorphic-unfetch';
 import querystring from 'querystring';
 
-const {
-  SPOTIFY_CLIENT_ID: client_id,
-  SPOTIFY_CLIENT_SECRET: client_secret,
-  SPOTIFY_REFRESH_TOKEN: refresh_token
-} = process.env;
+const client_id = process.env.SPOTIFY_CLIENT_ID;
+const client_secret = process.env.SPOTIFY_CLIENT_SECRET;
+const refresh_token = process.env.SPOTIFY_REFRESH_TOKEN;
 
 const basic = Buffer.from(`${client_id}:${client_secret}`).toString('base64');
 const TOP_TRACKS_ENDPOINT = `https://api.spotify.com/v1/me/top/tracks`;

--- a/data/snippets/spotify.mdx
+++ b/data/snippets/spotify.mdx
@@ -39,11 +39,9 @@ export default async (_, res) => {
 import fetch from 'isomorphic-unfetch';
 import querystring from 'querystring';
 
-const {
-  SPOTIFY_CLIENT_ID: client_id,
-  SPOTIFY_CLIENT_SECRET: client_secret,
-  SPOTIFY_REFRESH_TOKEN: refresh_token
-} = process.env;
+const client_id = process.env.SPOTIFY_CLIENT_ID;
+const client_secret = process.env.SPOTIFY_CLIENT_SECRET;
+const refresh_token = process.env.SPOTIFY_REFRESH_TOKEN;
 
 const basic = Buffer.from(`${client_id}:${client_secret}`).toString('base64');
 const NOW_PLAYING_ENDPOINT = `https://api.spotify.com/v1/me/player/currently-playing`;

--- a/lib/spotify.js
+++ b/lib/spotify.js
@@ -1,10 +1,8 @@
 import querystring from 'querystring';
 
-const {
-  SPOTIFY_CLIENT_ID: client_id,
-  SPOTIFY_CLIENT_SECRET: client_secret,
-  SPOTIFY_REFRESH_TOKEN: refresh_token
-} = process.env;
+const client_id = process.env.SPOTIFY_CLIENT_ID;
+const client_secret = process.env.SPOTIFY_CLIENT_SECRET;
+const refresh_token = process.env.SPOTIFY_REFRESH_TOKEN;
 
 const basic = Buffer.from(`${client_id}:${client_secret}`).toString('base64');
 const NOW_PLAYING_ENDPOINT = `https://api.spotify.com/v1/me/player/currently-playing`;


### PR DESCRIPTION
From [Next.js docs](https://nextjs.org/docs/basic-features/environment-variables#loading-environment-variables):

> **Note**: In order to keep server-only secrets safe, Next.js replaces `process.env.*` with the correct values at build time. This means that `process.env` is not a standard JavaScript object, so you’re not able to use [object destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment). Environment variables must be referenced as e.g. `process.env.NEXT_PUBLIC_PUBLISHABLE_KEY`, not `const { NEXT_PUBLIC_PUBLISHABLE_KEY } = process.env`.