### PR TITLE
Fix toggle mode icon mismatch

### DIFF
--- a/components/Container.js
+++ b/components/Container.js
@@ -8,7 +8,7 @@ import Footer from '@/components/Footer';
 
 export default function Container(props) {
   const [mounted, setMounted] = useState(false);
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
 
   // After mounting, we have access to the theme
   useEffect(() => setMounted(true), []);
@@ -63,7 +63,7 @@ export default function Container(props) {
               stroke="currentColor"
               className="h-4 w-4 text-gray-800 dark:text-gray-200"
             >
-              {theme === 'dark' ? (
+              {resolvedTheme === 'dark' ? (
                 <path
                   strokeLinecap="round"
                   strokeLinejoin="round"


### PR DESCRIPTION
The toggle mode icon is not in sync when it respects the system mode

![image](https://user-images.githubusercontent.com/862774/113936415-049cca80-97f8-11eb-9f3a-e1575df1a40e.png)


From the next-theme [FAQ](https://www.npmjs.com/package/next-themes#faq):

> When supporting the System theme preference, you want to make sure that's reflected in your UI. This means your buttons, selects, dropdowns, or whatever you use to indicate the current theme should say "System" when the System theme preference is active.
> 
> If we didn't distinguish between theme and resolvedTheme, the UI would show "Dark" or "Light", when it should really be "System".