### PR TITLE
- Fix sitemap links duplication

### DIFF
--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -8,8 +8,10 @@ const prettier = require('prettier');
   const pages = await globby([
     'pages/*.js',
     'data/**/*.mdx',
+    '!data/*.mdx',
     '!pages/_*.js',
-    '!pages/api'
+    '!pages/api',
+    '!pages/404.js',
   ]);
 
   const sitemap = `


### PR DESCRIPTION
I noticed you have a link duplication in your sitemap (https://leerob.io/uses). This is due to the sitemap generator script add uses from 2 places:

1- The pages directory ( uses.js )
2- The data directory ( uses.mdx )

By excluding the top level of the data directory ( which you use for some pages i guess?) then the generator will add the page only from pages directory.

I also excluded the 404 page, not sure if you wanna keep it or not ( and maybe add 500 for the future! )

You can test for duplicates here https://www.mysitemapgenerator.com/service/check.html