### PR TITLE
fix type error while listening to a podcast on spotify

### DIFF
--- a/pages/api/now-playing.js
+++ b/pages/api/now-playing.js
@@ -8,6 +8,11 @@ export default async function handler(_, res) {
   }
 
   const song = await response.json();
+  
+  if (song.item === null) {
+    return res.status(200).json({ isPlaying: false })
+  }
+  
   const isPlaying = song.is_playing;
   const title = song.item.name;
   const artist = song.item.artists.map((_artist) => _artist.name).join(', ');


### PR DESCRIPTION
Spotify can also be used to listen to podcast instead of songs

I noticed when I was listening to a podcast rather than a song on spotify, the api returned a typeerror

![typeerror on podcast](https://user-images.githubusercontent.com/36405030/120276550-77926100-c2d0-11eb-993a-a9a633b45710.png)



because the song response json was 



![podcast response](https://user-images.githubusercontent.com/36405030/120276655-9a247a00-c2d0-11eb-80f9-c95cb33daeb2.png)

the returned json doesnt offers much in terms of podcast, so i think it will be better to return not playing as output

 