### PR TITLE
Make forms work without JavaScript.

### DIFF
--- a/components/Guestbook.js
+++ b/components/Guestbook.js
@@ -92,9 +92,15 @@ export default function Guestbook({ initialEntries }) {
           Share a message for a future visitor of my site.
         </p>
         {user?.name ? (
-          <form className="relative my-4" onSubmit={leaveEntry}>
+          <form
+            action="/api/guestbook"
+            method="post"
+            className="relative my-4"
+            onSubmit={leaveEntry}
+          >
             <input
               ref={inputEl}
+              name="body"
               aria-label="Your message"
               placeholder="Your message..."
               required

--- a/components/Subscribe.js
+++ b/components/Subscribe.js
@@ -54,11 +54,17 @@ export default function Subscribe() {
         Get emails from me about web development, tech, and early access to new
         articles.
       </p>
-      <form className="relative my-4" onSubmit={subscribe}>
+      <form
+        action="/api/subscribe"
+        method="post"
+        className="relative my-4"
+        onSubmit={subscribe}
+      >
         <input
           ref={inputEl}
           aria-label="Email for newsletter"
           placeholder="tim@apple.com"
+          name="email"
           type="email"
           autoComplete="email"
           required


### PR DESCRIPTION
Since I was already using the HTML `form` element with a proper button `type="submit"`, this was pretty easy. Just needed to gracefully degrade when JavaScript is disabled to call the API routes directly. 