### PR TITLE
Prevent render <noscript> img on client when JavaScript is available

### DIFF
--- a/lib/patch-preact.js
+++ b/lib/patch-preact.js
@@ -1,0 +1,16 @@
+/**
+ * Patch that makes Preact skip noscript contents from "next/image" on the client only
+ */
+import { options } from 'preact';
+
+export const patchPreact = () => {
+  const CLIENT = typeof document !== 'undefined';
+
+  const old = options.vnode;
+  options.vnode = (vnode) => {
+    if (vnode.type === 'noscript' && CLIENT) {
+      vnode.props.children = null;
+    }
+    if (old) old(vnode);
+  };
+};

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -3,7 +3,10 @@ import '@/styles/global.css';
 import { ThemeProvider } from 'next-themes';
 import { MDXProvider } from '@mdx-js/react';
 import { useAnalytics } from '@/lib/analytics';
+import { patchPreact } from '@/lib/patch-preact';
 import MDXComponents from '@/components/MDXComponents';
+
+patchPreact();
 
 export default function App({ Component, pageProps }) {
   useAnalytics();


### PR DESCRIPTION
If you check the console, you'll see something like this inside `<Image />` component when the page is using `preact`:
![image](https://user-images.githubusercontent.com/32134586/123030213-ce172a80-d3b8-11eb-879f-fab3435b71ab.png)

This will render everything inside `<noscript>` and makes all images loading at once, instead of loading when it appears on the screen:
![image](https://user-images.githubusercontent.com/32134586/123033999-19343c00-d3bf-11eb-8d9b-c4a4bc1dd30c.png)

[source](https://leerob.io/blog/style-guides-component-libraries-design-systems)

---

Meanwhile, when you saw some `react` page, inside `noscript` tag appears something like that:
![image](https://user-images.githubusercontent.com/32134586/123030307-facb4200-d3b8-11eb-940a-05dc2b5a3579.png)
[source](https://nextjs.org/live)

---

This PR fix this issue on `preact`, and makes `next/image` only load when necessary:
![image](https://user-images.githubusercontent.com/32134586/123034199-762ff200-d3bf-11eb-9bbe-4fd280cfd016.png)

> NOTE: Still works when JavaScript is disabled!

[Preact issue that mentions this workaround](https://github.com/preactjs/preact/issues/2797#issuecomment-714508329)
