### PR TITLE
Add "skip-link content" a scroll-margin-top

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -41,6 +41,10 @@ html {
   @apply absolute px-4 py-2 transition-transform duration-200 transform -translate-y-12 left-1/4 focus:top-4 focus:translate-y-3 -top-8;
 }
 
+#skip{
+  scroll-margin-top: theme('spacing[32]');
+}
+
 @supports not (backdrop-filter: none) {
   .sticky-nav {
     backdrop-filter: none;


### PR DESCRIPTION
Your skip-link "skipping" content too much until it covered by navbar.
This PR adding `scroll-margin-top` so the main content still readable after skipping.
![iC5qz5CliJ](https://user-images.githubusercontent.com/35674157/124067226-3ecae080-da64-11eb-9191-2affd52391ce.gif)

