### PR TITLE
Error:0909006C:PEM No start line

### DIFF
--- a/data/snippets/google-sheets.mdx
+++ b/data/snippets/google-sheets.mdx
@@ -12,7 +12,7 @@ export default async (req, res) => {
     credentials: {
       client_email: process.env.GOOGLE_CLIENT_EMAIL,
       client_id: process.env.GOOGLE_CLIENT_ID,
-      private_key: process.env.GOOGLE_PRIVATE_KEY
+      private_key: process.env.GOOGLE_PRIVATE_KEY.replace(/\\n/g, '\n'),
     },
     scopes: [
       'https://www.googleapis.com/auth/drive',


### PR DESCRIPTION
The code snippet was throwing the following error -
```js
error:0909006C:PEM routines:get_name:no start line
```
It seemed like the `PRIVATE_KEY` has to be parsed and should not include any `/` and `\n`.
The output has to be multi-line as follows: -
```
-----BEGIN PRIVATE KEY-----
<key>
-----END PRIVATE KEY-----
```
We can easily do this using the replace method.
Here is where I found the fix!
https://github.com/theoephraim/node-google-spreadsheet/issues/244