### PR TITLE
Fix incorrect link to `rehype-prism-plus`

### DIFF
--- a/data/blog/mdx.mdx
+++ b/data/blog/mdx.mdx
@@ -178,7 +178,7 @@ export async function getStaticProps({ params }) {
 - [rehype-slug](https://github.com/rehypejs/rehype-slug)
 - [rehype-code-titles](https://github.com/josestg/rehype-code-title)
 - [rehype-autolink-headings](https://github.com/rehypejs/rehype-autolink-headings)
-- [rehype-prism-plus](https://github.com/Val-istar-Guo/rehype-prism)
+- [rehype-prism-plus](https://github.com/timlrx/rehype-prism-plus)
 
 ```js:lib/mdx.js
 import { join } from 'path';


### PR DESCRIPTION
Closes https://github.com/leerob/leerob.io/issues/360.