### PR TITLE
fix: broken link metric card

### DIFF
--- a/data/blog/fetching-data-with-swr.mdx
+++ b/data/blog/fetching-data-with-swr.mdx
@@ -82,7 +82,7 @@ function Unsplash() {
 export default Unsplash;
 ```
 
-_Note_: The `MetricCard` source code is [here](https://github.com/leerob/leerob.io/blob/master/components/metrics/Card.js).
+_Note_: The `MetricCard` source code is [here](https://github.com/leerob/leerob.io/blob/6271b16d9f796e5ddbe8ab8289f98b188c688ef3/components/metrics/Card.tsx).
 
 ## Example
 


### PR DESCRIPTION
Updated the source link for metric card with a permalink blob

Note: Not for hacktober