### PR TITLE
Update font subsetting - it is incorrect now

### DIFF
--- a/data/blog/fonts.mdx
+++ b/data/blog/fonts.mdx
@@ -116,6 +116,11 @@ Font files contain multiple languages and glyphs, which increase the file size. 
 
 For example, we might use the Inter variable font and subset to latin languages.
 
+Several tools are available to subset fonts - such as:
+- [Font Squirrel](https://www.fontsquirrel.com/tools/webfont-generator) (web based)
+- [Fontie](https://fontie.pixelsvsbytes.com/webfont-generator) (web based)
+- [Fontforge](https://fontforge.org/) (open source Mac/Windows/Linux tool)
+
 ```css
 @font-face {
   font-family: 'Inter';
@@ -123,9 +128,6 @@ For example, we might use the Inter variable font and subset to latin languages.
   font-weight: 100 900; // Range of weights supported
   font-display: optional;
   src: url(/fonts/inter-var-latin.woff2) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-    U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
-    U+FEFF, U+FFFD;
 }
 ```
 


### PR DESCRIPTION
The unicode-range function is for different font files for different languages- the caveat for the usecase you are describing is identified here:

https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/unicode-range - 
"The unicode-range CSS descriptor sets the specific range of characters to be used from a font defined by @font-face and made available for use on the current page. If the page doesn't use any character in this range, the font is not downloaded; *if it uses at least one, the whole font is downloaded.*"

You could use something like font-squirrel(https://www.fontsquirrel.com/tools/webfont-generator), fontie(https://fontie.pixelsvsbytes.com/webfont-generator), or fontforge (https://fontforge.org/en-US/) to subset your self hosted fonts instead to reduce the file size of the font files themselves.

Btw I have found your content immensely valuable - thank you.