### PR TITLE
Delete outdated information in a blog

### DIFF
--- a/data/blog/css-with-react.mdx
+++ b/data/blog/css-with-react.mdx
@@ -262,7 +262,6 @@ With the combination of [Tailwind UI](https://tailwindui.com/), you can easily b
   title="Tailwind"
   cons={[
     `You don't want (potentially) long class names.`,
-    `You don't want to configure a toolchain like PurgeCSS to use it effectively.`,
     `You don't want to learn Tailwind syntax, which is slightly different than standard CSS.`
   ]}
 />


### PR DESCRIPTION
Deleted this line "You don't want to configure a toolchain like PurgeCSS to use it effectively." because Tailwind no longer uses PurgeCSS under the hood.