### PR TITLE
Use compact notation for Tweet component

### DIFF
--- a/components/Tweet.tsx
+++ b/components/Tweet.tsx
@@ -140,7 +140,7 @@ export default function Tweet({
               d="M14.046 2.242l-4.148-.01h-.002c-4.374 0-7.8 3.427-7.8 7.802 0 4.098 3.186 7.206 7.465 7.37v3.828c0 .108.045.286.12.403.143.225.385.347.633.347.138 0 .277-.038.402-.118.264-.168 6.473-4.14 8.088-5.506 1.902-1.61 3.04-3.97 3.043-6.312v-.017c-.006-4.368-3.43-7.788-7.8-7.79zm3.787 12.972c-1.134.96-4.862 3.405-6.772 4.643V16.67c0-.414-.334-.75-.75-.75h-.395c-3.66 0-6.318-2.476-6.318-5.886 0-3.534 2.768-6.302 6.3-6.302l4.147.01h.002c3.532 0 6.3 2.766 6.302 6.296-.003 1.91-.942 3.844-2.514 5.176z"
             />
           </svg>
-          <span>{new Number(public_metrics.reply_count).toLocaleString()}</span>
+          <span>{new Number(public_metrics.reply_count).toLocaleString('en', { notation: 'compact' })}</span>
         </a>
         <a
           className="flex items-center mr-4 !text-gray-500 hover:!text-green-600 transition hover:!underline"
@@ -155,7 +155,7 @@ export default function Tweet({
             />
           </svg>
           <span>
-            {new Number(public_metrics.retweet_count).toLocaleString()}
+            {new Number(public_metrics.retweet_count).toLocaleString('en', { notation: 'compact' })}
           </span>
         </a>
         <a
@@ -170,7 +170,7 @@ export default function Tweet({
               d="M12 21.638h-.014C9.403 21.59 1.95 14.856 1.95 8.478c0-3.064 2.525-5.754 5.403-5.754 2.29 0 3.83 1.58 4.646 2.73.813-1.148 2.353-2.73 4.644-2.73 2.88 0 5.404 2.69 5.404 5.755 0 6.375-7.454 13.11-10.037 13.156H12zM7.354 4.225c-2.08 0-3.903 1.988-3.903 4.255 0 5.74 7.035 11.596 8.55 11.658 1.52-.062 8.55-5.917 8.55-11.658 0-2.267-1.822-4.255-3.902-4.255-2.528 0-3.94 2.936-3.952 2.965-.23.562-1.156.562-1.387 0-.015-.03-1.426-2.965-3.955-2.965z"
             />
           </svg>
-          <span>{new Number(public_metrics.like_count).toLocaleString()}</span>
+          <span>{new Number(public_metrics.like_count).toLocaleString('en', { notation: 'compact' })}</span>
         </a>
       </div>
     </div>


### PR DESCRIPTION
Fixes #390 - Large numbers from comments, retweets, and likes cause the Tweet component to overflow on smaller screen devices.

Before:
![image](https://user-images.githubusercontent.com/20555214/146024478-13b2b48d-ede9-40a1-ae12-be91ab88b0c6.png)

After: 
![image](https://user-images.githubusercontent.com/20555214/146024756-f63347e7-b983-4e35-be21-86cd86f00eab.png)