### PR TITLE
fix: anchor underline bug

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -64,7 +64,7 @@ html {
 }
 
 .prose .anchor {
-  @apply absolute invisible;
+  @apply absolute invisible no-underline;
 
   margin-left: -1em;
   padding-right: 0.5em;
@@ -74,7 +74,7 @@ html {
 }
 
 .anchor:hover {
-  @apply visible no-underline;
+  @apply visible;
 }
 
 .prose a {
@@ -87,7 +87,7 @@ html {
 }
 
 .prose *:hover > .anchor {
-  @apply visible no-underline;
+  @apply visible;
 }
 
 .prose pre {


### PR DESCRIPTION
I noticed an underline under the "#" on the article anchors when you stop hovering.

![anchor-underline-bug](https://user-images.githubusercontent.com/20555214/153876847-e6ada4c5-70b9-43c3-817e-1265dff6f9ed.gif)

Setting `no-underline` on `.prose .anchor` fixes this issue, and we can also remove it on a couple of other selectors.

![anchor-hover-fixed](https://user-images.githubusercontent.com/20555214/153877581-c3f999fc-ca26-4af5-80a2-8de7de90b8b0.gif)
