### PR TITLE
chore: update preact to 10.6.6

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,6 +16,7 @@ module.exports = withContentlayer()({
     // Replace React with Preact only in client production build
     if (!dev && !isServer) {
       Object.assign(config.resolve.alias, {
+        'react/jsx-runtime.js': 'preact/compat/jsx-runtime',
         react: 'preact/compat',
         'react-dom/test-utils': 'preact/test-utils',
         'react-dom': 'preact/compat'

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "next-auth": "4.2.1",
     "next-contentlayer": "^0.0.34",
     "next-themes": "0.0.15",
-    "preact": "10.5.15",
+    "preact": "^10.6.6",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "swr": "1.2.1",
@@ -48,9 +48,6 @@
     "remark-gfm": "^3.0.1",
     "rss": "1.2.2",
     "typescript": "^4.5.5"
-  },
-  "resolutions": {
-    "preact": "10.5.15"
   },
   "prettier": {
     "arrowParens": "always",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3905,10 +3905,10 @@ preact-render-to-string@^5.1.19:
   dependencies:
     pretty-format "^3.8.0"
 
-preact@10.5.15, preact@^10.6.3:
-  version "10.5.15"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"
-  integrity sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==
+preact@^10.6.3, preact@^10.6.6:
+  version "10.6.6"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.6.6.tgz#f1899bc8dab7c0788b858481532cb3b5d764a520"
+  integrity sha512-dgxpTFV2vs4vizwKohYKkk7g7rmp1wOOcfd4Tz3IB3Wi+ivZzsn/SpeKJhRENSE+n8sUfsAl4S3HiCVT923ABw==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
Update to use the latest version of preact ([10.6.6](https://github.com/preactjs/preact/releases/tag/10.6.6)).