### PR TITLE
Fixed 'system' theme issue in ImageWithTheme

### DIFF
--- a/components/ImageWithTheme.tsx
+++ b/components/ImageWithTheme.tsx
@@ -2,12 +2,12 @@ import Image from 'next/image';
 import { useTheme } from 'next-themes';
 
 export default function ImageWithTheme(props) {
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
 
   return (
     <Image
       alt={props.alt}
-      src={theme === 'light' ? props.light : props.dark}
+      src={resolvedTheme === 'light' ? props.light : props.dark}
       {...props}
     />
   );


### PR DESCRIPTION
When loading a page for the first time, the `theme` property returned can be 'system' 
This then defaults to dark, even if the system is set to light.

Using the `resolvedTheme` will return the correct theme set by the system. https://github.com/pacocoursey/next-themes#usetheme-1