### PR TITLE
Decrease JS by targeting modern browsers only.

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,10 @@ module.exports = withContentlayer({
       'pbs.twimg.com' // Twitter Profile Picture
     ]
   },
+  experimental: {
+    legacyBrowsers: false,
+    browsersListForSwc: true
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
https://github.com/vercel/next.js/pull/36584

Should be about 7% faster: https://estimator.dev/#leerob.io

**Default targets:**
- Chrome 61
- Edge 16
- Firefox 60
- Opera 48
- Safari 11