### PR TITLE
Check for post before creating views

### DIFF
--- a/pages/api/views/[slug].ts
+++ b/pages/api/views/[slug].ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import prisma from 'lib/prisma';
-import { previewClient } from 'lib/sanity-server';
+import { getClient } from 'lib/sanity-server';
 import { postBySlugQuery } from 'lib/queries';
 
 export default async function handler(
@@ -11,7 +11,7 @@ export default async function handler(
     const slug = req.query.slug.toString();
 
     if (req.method === 'POST') {
-      const post = await previewClient.fetch(postBySlugQuery, {
+      const post = await getClient(req.preview ?? false).fetch(postBySlugQuery, {
         slug,
       });
 

--- a/pages/api/views/[slug].ts
+++ b/pages/api/views/[slug].ts
@@ -1,5 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import prisma from 'lib/prisma';
+import { previewClient } from 'lib/sanity-server';
+import { postBySlugQuery } from 'lib/queries';
 
 export default async function handler(
   req: NextApiRequest,
@@ -9,6 +11,14 @@ export default async function handler(
     const slug = req.query.slug.toString();
 
     if (req.method === 'POST') {
+      const post = await previewClient.fetch(postBySlugQuery, {
+        slug,
+      });
+
+      if (!post) {
+        return res.status(401).json({ message: 'Invalid slug' });
+      }
+
       const newOrUpdatedViews = await prisma.views.upsert({
         where: { slug },
         create: {


### PR DESCRIPTION
People can create views with random names and can then fill the whole database. I added a check for an existing post so only real posts can be added