### PR TITLE
Fix on demand ISR revalidation with Sanity webhook

### DIFF
--- a/pages/api/revalidate.ts
+++ b/pages/api/revalidate.ts
@@ -1,18 +1,20 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { isValidRequest } from '@sanity/webhook';
+import { isValidSignature, SIGNATURE_HEADER_NAME } from '@sanity/webhook';
 import { sanityClient } from 'lib/sanity-server';
 import { postUpdatedQuery } from 'lib/queries';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
-) {
-  // This isn't working yet - not sure why
-  if (!isValidRequest(req, process.env.SANITY_STUDIO_REVALIDATE_SECRET)) {
-    return res.status(401).json({ message: 'Invalid request' });
+) {  
+  const signature = req.headers[SIGNATURE_HEADER_NAME] as string
+  const body = await readBody(req) // Read the body into a string
+  if (!isValidSignature(body, signature, process.env.SANITY_STUDIO_REVALIDATE_SECRET)) {
+    res.status(401).json({ message: 'Invalid signature' })
+    return
   }
 
-  const { _id: id } = req.body;
+  const { _id: id } = JSON.parse(body);
   if (typeof id !== 'string' || !id) {
     return res.status(400).json({ message: 'Invalid _id' });
   }
@@ -27,4 +29,18 @@ export default async function handler(
   } catch (err) {
     return res.status(500).json({ message: err.message });
   }
+}
+
+export const config = {
+  api: {
+    bodyParser: false
+  }
+}
+
+async function readBody(readable: NextApiRequest) {
+  const chunks = []
+  for await (const chunk of readable) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
+  }
+  return Buffer.concat(chunks).toString('utf8')
 }


### PR DESCRIPTION
This PR fixes ISR revalidation.
[@sanity/webhook](https://github.com/sanity-io/webhook-toolkit) recommends verifying raw request body - see [migration guide](https://github.com/sanity-io/webhook-toolkit#migration).

Related issues:
- #532 
- #497 