### PR TITLE
Add preferred color scheme for safari.

### DIFF
--- a/components/Container.tsx
+++ b/components/Container.tsx
@@ -62,6 +62,16 @@ export default function Container(props) {
         <meta name="twitter:title" content={meta.title} />
         <meta name="twitter:description" content={meta.description} />
         <meta name="twitter:image" content={meta.image} />
+        <meta
+          name="theme-color"
+          content="#f9fafb"
+          media="(prefers-color-scheme: light)"
+        />
+        <meta
+          name="theme-color"
+          content="#000000"
+          media="(prefers-color-scheme: dark)"
+        />
         {meta.date && (
           <meta property="article:published_time" content={meta.date} />
         )}


### PR DESCRIPTION
### Problem
Using Safari, particularly on iOS, the menu bar remains to be white in dark mode (see screenshot).

![IMG_C701035DB727-1](https://user-images.githubusercontent.com/33464395/199187414-164c4b73-bc38-409e-be7d-623e54474f96.jpeg)

### Solution
Use meta tags for ["theme-color"](https://css-tricks.com/meta-theme-color-and-trickery/).

### Other suggestions
Switching to dark mode automatically when system preferences change might be desirable.
Let me know if that is smth you might find useful.
This could be achieved with:

```ts
  const { resolvedTheme, setTheme } = useTheme();

  useEffect(() => {
    const modeMe = (e) => {
      setTheme(e.matches ? 'dark' : 'light');
    };
    const matchMedia = window.matchMedia('(prefers-color-scheme: dark)');

    setTheme(matchMedia.matches ? 'dark' : 'light');
    matchMedia.addEventListener('change', modeMe);

    return () => matchMedia.removeEventListener('change', modeMe);
  }, [setTheme]);
```
