### PR TITLE
Remove the extra main tag

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,10 +14,10 @@ export default function App({
   return (
     <SessionProvider session={session}>
       <ThemeProvider attribute="class">
-        <main className={interVariable.className}>
+        <div className={interVariable.className}>
           <Component {...pageProps} />
           <Analytics />
-        </main>
+        </div>
       </ThemeProvider>
     </SessionProvider>
   );


### PR DESCRIPTION
Hey,

I noticed that there are two main tags on the site, which is considered an error by the [HTML standard](https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element)
P.S. the second main tag can be found in the [container component](https://github.com/leerob/leerob.io/blob/main/components/Container.tsx#L118)
