### PR TITLE
fix: view count update on new posts

### DIFF
--- a/pages/api/views/[slug].ts
+++ b/pages/api/views/[slug].ts
@@ -13,11 +13,7 @@ export default async function handler(
       .select(['count'])
       .execute();
 
-    if (!data.length) {
-      return 0;
-    }
-
-    const views = Number(data[0].count);
+    const views = !data.length ? 0 : Number(data[0].count);
 
     if (req.method === 'POST') {
       await queryBuilder


### PR DESCRIPTION
Solves #575 
I was playing around with my [own fork](https://shreyans-sh.vercel.app) and the view count on posts wasn't updating so after some searching I found that new posts with no DB entry were returning 0 before the POST request could execute.

Signed-off-by: Shreyans Jain <shreyansthebest2007@gmail.com>