### PR TITLE
fixes json ld hydration and view counter

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import Script from "next/script";
 import { Mdx } from 'components/mdx';
 import { allBlogs } from 'contentlayer/generated';
 import { getTweets } from 'lib/twitter';
@@ -66,9 +67,7 @@ export default async function Blog({ params }) {
 
   return (
     <section>
-      <script type="application/ld+json">
-        {JSON.stringify(post.structuredData)}
-      </script>
+      <Script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(post.structuredData)}} />
       <h1 className="font-bold text-3xl font-serif max-w-[650px]">
         <Balancer>{post.title}</Balancer>
       </h1>

--- a/app/blog/view-counter.tsx
+++ b/app/blog/view-counter.tsx
@@ -24,8 +24,10 @@ export default function ViewCounter({
   trackView: boolean;
 }) {
   const { data } = useSWR<PostView[]>('/api/views', fetcher);
-  const viewsForSlug = data && data.find((view) => view.slug === slug);
-  const views = new Number(viewsForSlug?.count || 0);
+  const views = new Number(
+    data && typeof data.find === 'function' ? 
+      data.find((view) => view.slug === slug)?.count || 0 : 0
+  );
 
   useEffect(() => {
     const registerView = () =>


### PR DESCRIPTION
I was reading your blog which has given me some good inspiration. I reloaded the page while I had the Chrome console open, and noticed a React hydration error. Figured out that this was caused by the current implementation of setting the JSON-LD value.

Also, noticed that the `view-counter.tsx` threw an error saying that find was not a function - I think this only effects people who fork your repo and run the setup script since there is no view information returned from the api.