### PR TITLE
refactor: remove classe overflow-scroll in nav

### DIFF
--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -90,7 +90,7 @@ export default function Navbar() {
           <Logo />
         </div>
         <nav
-          className="flex flex-row md:flex-col items-start relative overflow-scroll px-4 md:px-0 pb-0 fade md:overflow-auto scroll-pr-6 md:relative"
+          className="flex overflow-hidden flex-row md:flex-col items-start relative overflow-scroll px-4 md:px-0 pb-0 fade md:overflow-auto scroll-pr-6 md:relative"
           id="nav"
         >
           <div className="flex flex-row md:flex-col space-x-0 pr-10 mb-2 mt-2 md:mt-0">

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -90,7 +90,7 @@ export default function Navbar() {
           <Logo />
         </div>
         <nav
-          className="flex overflow-hidden flex-row md:flex-col items-start relative overflow-scroll px-4 md:px-0 pb-0 fade md:overflow-auto scroll-pr-6 md:relative"
+          className="flex overflow-hidden flex-row md:flex-col items-start relative px-4 md:px-0 pb-0 fade md:overflow-auto scroll-pr-6 md:relative"
           id="nav"
         >
           <div className="flex flex-row md:flex-col space-x-0 pr-10 mb-2 mt-2 md:mt-0">


### PR DESCRIPTION
by accident I ended up not removing the class and overwriting the one that already existed.

