### PR TITLE
Update CSP rule for font-src 'self' to have data

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -42,7 +42,7 @@ const ContentSecurityPolicy = `
     img-src * blob: data:;
     media-src 'none';
     connect-src *;
-    font-src 'self';
+    font-src 'self' data:;
 `;
 
 const securityHeaders = [


### PR DESCRIPTION
Update CSP rule for font-src 'self' to have data as it is currently violated when using the next/font/local