### PR TITLE
Update using-nextjs.mdx, correct Meta team name

### DIFF
--- a/content/using-nextjs.mdx
+++ b/content/using-nextjs.mdx
@@ -223,7 +223,7 @@ Definitely not intentional.
 
 Next.js is placing a [large bet](https://twitter.com/dan_abramov/status/1650923730233700354) on the future of React. The App Router builds on many features the React team has been working on for years. Building and supporting a framework requires a non-trivial amount of work. [Redwood is doing the same](https://tom.preston-werner.com/2023/05/30/redwoods-next-epoch-all-in-on-rsc).
 
-In retrospect, we could have worked more closely with the Meta team on making some docs changes directly to the React docs versus the Next.js docs. Thankfully, this has picked up a lot and we are actively collaborating with the team at Meta. Shoutout to the Meta learning & development team.
+In retrospect, we could have worked more closely with the Meta team on making some docs changes directly to the React docs versus the Next.js docs. Thankfully, this has picked up a lot and we are actively collaborating with the team at Meta. Shoutout to Meta's Learning & Advocacy team.
 
 APIs that Next.js uses, like [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus), are now documented in the React docs. Even experimental React APIs like [tainting](https://react.dev/reference/react/experimental_taintUniqueValue) are now documented. They're publishing a _lot_ of great docs on their [new site](https://react.dev/learn) (which they worked on for many years).
 


### PR DESCRIPTION
Small fix, team's name is Learning and Advocacy. 🙂