### PR TITLE
Update README for Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Running Locally
 
-This application requires Node.js v16.13+.
+This application requires Node.js v18.17+.
 
 ```bash
 git clone https://github.com/leerob/leerob.io.git


### PR DESCRIPTION
Since Next.js 14, the minimum required Node.js version is now 18.17