### PR TITLE
Rephrasing setup comment

### DIFF
--- a/setup.mjs
+++ b/setup.mjs
@@ -52,7 +52,7 @@ const deleteFolderRecursive = async (path) => {
 
   if (process.env.IS_TEMPLATE === 'false') {
     // This means it's not the template, it's my legit site
-    // I orderride the env variable for my site. This means that when
+    // I override the env variable for my site. This means that when
     // folks clone this repo for the first time, it will delete my personal content
     return;
   }

--- a/setup.mjs
+++ b/setup.mjs
@@ -51,9 +51,11 @@ const deleteFolderRecursive = async (path) => {
   dotenv.config();
 
   if (process.env.IS_TEMPLATE === 'false') {
-    // This means it's not the template, it's my legit site
-    // I override the env variable for my site. This means that when
-    // folks clone this repo for the first time, it will delete my personal content
+    // Before the setup, we check the environment variable `IS_TEMPLATE`.
+    // In this repository, its value is initially set to true, but on
+    // my personal site, I override it to false. This means that when
+    // folks clone it for the first time, all my personal content will
+    // be deleted, so they can start fresh.
     return;
   }
 


### PR DESCRIPTION
Hi team, I had noticed a typo (*'orderrides'*) in the setup.mjs file and seized the opportunity to overhaul the wording of that particular comment. In particular, I've aimed to adopt a clearer, more straightforward style to explain the usage of the *'IS_TEMPLATE'* environment variable in the setup process.

The original explanation seemed a bit too convoluted and potentially confusing, especially for non-native English speakers. I believe this new structure is more user-friendly and will make the message more accessible to anyone delving into the code.