### PR TITLE
Append hard-coded time to publishedAt MDX frontmatter to prevent off-by-one day error

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -51,6 +51,9 @@ export async function generateMetadata({
 
 function formatDate(date: string) {
   let currentDate = new Date();
+  if (!date.includes('T')) {
+    date = `${date}T00:00:00`;
+  }
   let targetDate = new Date(date);
 
   let yearsAgo = currentDate.getFullYear() - targetDate.getFullYear();


### PR DESCRIPTION
Append hard-coded THH:MM:SS or 00:00:00 if no time component exists in publishedAt frontmatter property of MDX.

Addresses #681 