### PR TITLE
Update publishedAt in rust.mdx

### DIFF
--- a/content/rust.mdx
+++ b/content/rust.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rust Is The Future of JavaScript Infrastructure
-publishedAt: Nov 11, 2021
+publishedAt: '2021-11-11'
 summary: Why is Rust being used to replace parts of the JavaScript web ecosystem like minification (Terser), transpilation (Babel), formatting (Prettier), bundling (webpack), linting (ESLint), and more?
 ---
 


### PR DESCRIPTION
This commit fixes the invalid date in the Rust blog post 🙂.
<img width="721" alt="Screenshot 2023-12-13 at 18 03 07" src="https://github.com/leerob/leerob.io/assets/65172423/22fcf831-db08-4098-8085-e4a8bf0443a5">
