### PR TITLE
fix: syntax color for light mode

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -15,6 +15,8 @@
   --sh-keyword: #e02518;
   --sh-comment: #a19595;
   --sh-jsxliterals: #6266d1;
+  --sh-property: #e25a1c;
+  --sh-entity: #e25a1c;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
Fixes the color of `property` and `entity` strings in light mode.

![screenshot](https://github.com/leerob/leerob.io/assets/124599/641a5bd7-f97a-4013-9f49-50e2c38e8496)
