### PR TITLE
Add one-rule prettier config to prefer single quotes

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,0 @@
-{
-  "singleQuote": true
-}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "sugar-high": "^0.6.0",
     "tailwindcss": "^3.4.1",
     "typescript": "5.3.3"
+  },
+  "prettier": {
+    "singleQuote": true
   }
 }


### PR DESCRIPTION
This configuration is pretty minimal and is equivalent to setting

```json
"prettier.singleQuote": true
```

in VS Code's user settings.

The difference is that now this setting is picked up by the `prettier` CLI or others editors that use `prettier` to format.