### PR TITLE
Fix tweet images not appearing

### DIFF
--- a/app/components/tweet.tsx
+++ b/app/components/tweet.tsx
@@ -1,4 +1,6 @@
+import Image from 'next/image';
 import { getTweet } from 'react-tweet/api';
+import type { TwitterComponents } from 'react-tweet';
 import { Suspense } from 'react';
 import {
   TweetSkeleton,
@@ -7,6 +9,11 @@ import {
   type TweetProps,
 } from 'react-tweet';
 import './tweet.css';
+
+const components: TwitterComponents = {
+  AvatarImg: (props) => <Image {...props} />,
+  MediaImg: (props) => <Image {...props} fill />,
+};
 
 const TweetContent = async ({ id, components, onError }: TweetProps) => {
   let error;
@@ -36,7 +43,7 @@ export async function TweetComponent({ id }: { id: string }) {
     <div className="tweet my-6">
       <div className={`flex justify-center`}>
         {/* <Suspense fallback={<TweetSkeleton />}> */}
-        <ReactTweet id={id} />
+        <ReactTweet id={id} components={components} />
         {/* </Suspense> */}
       </div>
     </div>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -38,6 +38,12 @@ const nextConfig = {
       },
     ];
   },
+  images: {
+    remotePatterns: [
+      { protocol: 'https', hostname: 'pbs.twimg.com' },
+      { protocol: 'https', hostname: 'abs.twimg.com' },
+    ],
+  },
 };
 
 const ContentSecurityPolicy = `


### PR DESCRIPTION
Currently your website blog in prod. has the embedded tweets missing their images.

Exhibit A: https://leerob.io/blog/using-nextjs

Following the standard react-tweet library documentation:
https://react-tweet.vercel.app/next#adding-nextimage

I've added the minimal missing lines to fix this.

Cloned the repo, added this commit, verified my local instance was pulling the images now, albeit with a little awkward shift via \<Image fill />