### PR TITLE
Fix clickable area of startup links

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -287,41 +287,31 @@ export default function Page() {
         </p>
       </div>
       <div className="my-8 flex h-14 w-full flex-row space-x-2 overflow-x-auto">
-        <div className="flex items-center justify-between rounded border border-neutral-200 bg-neutral-50 px-3 py-4 dark:border-neutral-700 dark:bg-neutral-800">
-          <a href="https://linear.app">
-            <svg width="78" height="20" role="img" aria-label="Linear logo">
-              <use href="/sprite.svg#linear" />
-            </svg>
-          </a>
-        </div>
-        <div className="flex items-center justify-between rounded border border-neutral-200 bg-neutral-50 px-3 py-4 dark:border-neutral-700 dark:bg-neutral-800">
-          <a href="https://supabase.com">
-            <svg width="100" height="19" role="img" aria-label="Supabase logo">
-              <use href="/sprite.svg#supabase" />
-            </svg>
-          </a>
-        </div>
-        <div className="flex items-center justify-between rounded border border-neutral-200 bg-neutral-50 px-3 py-4 dark:border-neutral-700 dark:bg-neutral-800">
-          <a href="https://www.makeswift.com/blog/makeswift-is-joining-bigcommerce">
-            <svg width="96" height="19" role="img" aria-label="Makeswift logo">
-              <use href="/sprite.svg#makeswift" />
-            </svg>
-          </a>
-        </div>
-        <div className="flex items-center justify-between rounded border border-neutral-200 bg-neutral-50 px-3 py-4 dark:border-neutral-700 dark:bg-neutral-800">
-          <a href="https://resend.com">
-            <svg width="70" height="17" role="img" aria-label="Resend logo">
-              <use href="/sprite.svg#resend" />
-            </svg>
-          </a>
-        </div>
-        <div className="flex items-center justify-between rounded border border-neutral-200 bg-neutral-50 px-3 py-4 dark:border-neutral-700 dark:bg-neutral-800">
-          <a href="https://bun.sh">
-            <svg width="35" height="27" role="img" aria-label="Bun logo">
-              <use href="/sprite.svg#bun" />
-            </svg>
-          </a>
-        </div>
+        <a href="https://linear.app" className="flex items-center justify-between rounded border border-neutral-200 bg-neutral-50 px-3 py-4 dark:border-neutral-700 dark:bg-neutral-800">
+          <svg width="78" height="20" role="img" aria-label="Linear logo">
+            <use href="/sprite.svg#linear" />
+          </svg>
+        </a>
+        <a href="https://supabase.com" className="flex items-center justify-between rounded border border-neutral-200 bg-neutral-50 px-3 py-4 dark:border-neutral-700 dark:bg-neutral-800">
+          <svg width="100" height="19" role="img" aria-label="Supabase logo">
+            <use href="/sprite.svg#supabase" />
+          </svg>
+        </a>
+        <a href="https://www.makeswift.com/blog/makeswift-is-joining-bigcommerce" className="flex items-center justify-between rounded border border-neutral-200 bg-neutral-50 px-3 py-4 dark:border-neutral-700 dark:bg-neutral-800">
+          <svg width="96" height="19" role="img" aria-label="Makeswift logo">
+            <use href="/sprite.svg#makeswift" />
+          </svg>
+        </a>
+        <a href="https://resend.com" className="flex items-center justify-between rounded border border-neutral-200 bg-neutral-50 px-3 py-4 dark:border-neutral-700 dark:bg-neutral-800">
+          <svg width="70" height="17" role="img" aria-label="Resend logo">
+            <use href="/sprite.svg#resend" />
+          </svg>
+        </a>
+        <a href="https://bun.sh" className="flex items-center justify-between rounded border border-neutral-200 bg-neutral-50 px-3 py-4 dark:border-neutral-700 dark:bg-neutral-800">
+          <svg width="35" height="27" role="img" aria-label="Bun logo">
+            <use href="/sprite.svg#bun" />
+          </svg>
+        </a>
       </div>
       <div className="prose prose-neutral dark:prose-invert">
         <p>


### PR DESCRIPTION
Hey! While browsing the website I noticed one detail that I think is not working as it should.
Only the logos of the startups are wrapped with links, not the buttons themselves, which should also be clickable for the user

### How it looks right now:

![Group 2131327237 (2)](https://github.com/user-attachments/assets/d43e4b18-43b5-4ce7-87d2-14178d99fae7)

I added minimal changes to fix this. The block from startups now consists of links with logos (before div > a > svg)
Let me know what you think about this.