### PR TITLE
Remove non-existent /work route from sitemap

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -29,7 +29,7 @@ export default async function sitemap() {
     lastModified: new Date().toISOString()
   }));
 
-  const routes = ['', '/work'].map((route) => ({
+  const routes = [''].map((route) => ({
     url: `${SITE_URL}${route}`,
     lastModified: new Date().toISOString()
   }));


### PR DESCRIPTION
The sitemap includes a /work entry, but there is no app/work page in this template. This causes the generated sitemap to advertise a URL that returns 404, which can harm SEO for anyone using the template as-is.

This route appears to be leftover from the lee's personal site where a /work page exists. Removing it from the template sitemap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes sitemap output by removing an invalid route; no runtime logic or data handling changes beyond URL enumeration.
> 
> **Overview**
> Removes the `/work` entry from the generated sitemap so the sitemap no longer advertises a route that returns 404.
> 
> Sitemap generation otherwise remains the same, continuing to include the site root and note pages under `/n/*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6b3578e2b608a1a7040b6d802c83e32cd59bdd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->